### PR TITLE
Clean up JobWrappers::ResqueWrapper.perform

### DIFF
--- a/lib/active_job/job_wrappers/resque_wrapper.rb
+++ b/lib/active_job/job_wrappers/resque_wrapper.rb
@@ -13,14 +13,8 @@ module ActiveJob
           [ new(job), *args.prepend(job) ]
         end
 
-        def perform(*args)
-          unwrapped_job = args.first.constantize
-          
-          if args.many?
-            unwrapped_job.perform *args.from(1)
-          else
-            unwrapped_job.perform
-          end
+        def perform(job_name, *args)
+          job_name.constantize.perform(*args)
         end
       end
 


### PR DESCRIPTION
This is not only easier to read, but it'll also properly raise an `ArgumentError` rather than a `NoMethodError` when called with no arguments.

It also allocates 4 fewer objects per call (8 down from 12), and is ~85% faster according to this quick benchmark script:

``` ruby
require "bundler/setup"
require "active_job"
require "active_job/job_wrappers/resque_wrapper"
require "benchmark/ips"

class MyJob
  def self.perform(*args)
    #
  end
end

Benchmark.ips do |x|
  x.report "" do
    ActiveJob::JobWrappers::ResqueWrapper.perform("MyJob", 1, 2, 3)
  end
end
```

Before:

```
Calculating -------------------------------------
                         21722 i/100ms
-------------------------------------------------
                       322447.8 (±2.2%) i/s -    1629150 in   5.055077s
```

After:

```
Calculating -------------------------------------
                         30108 i/100ms
-------------------------------------------------
                       605060.2 (±2.7%) i/s -    3040908 in   5.029782s
```
