### PR TITLE
Refactor Resque adapter to be more consistent with others

### DIFF
--- a/lib/active_job/queue_adapters/resque_adapter.rb
+++ b/lib/active_job/queue_adapters/resque_adapter.rb
@@ -7,16 +7,12 @@ module ActiveJob
     class ResqueAdapter
       class << self
         def queue(job, *args)
-          Resque.enqueue *JobWrapper.wrap(job, args)
+          Resque.enqueue JobWrapper.new(job), job, *args
         end
       end
 
       class JobWrapper
         class << self
-          def wrap(job, args)
-            [ new(job), *args.prepend(job) ]
-          end
-
           def perform(job_name, *args)
             job_name.constantize.new.perform *Parameters.deserialize(args)
           end
@@ -27,7 +23,7 @@ module ActiveJob
         end
 
         def to_s
-          self.class.to_s
+          self.class.name
         end
       end
     end


### PR DESCRIPTION
Main point is getting rid of `JobWrapper.wrap` which is superfluous / not used any where else.
