### PR TITLE
Make tests for `Person` pass.

### DIFF
--- a/test/models/person.rb
+++ b/test/models/person.rb
@@ -2,18 +2,18 @@ require 'active_model/global_identification'
 
 class Person
   include ActiveModel::GlobalIdentification
-  
+
   attr_reader :id
-  
+
   def self.find(id)
     new(id)
   end
-  
+
   def initialize(id)
     @id = id
   end
-  
+
   def ==(other_person)
-    other_person.is_a?(Person) && id == other_person.id
+    other_person.is_a?(Person) && id.to_s == other_person.id.to_s
   end
 end


### PR DESCRIPTION
After #29, I found the tests fail. It didn't fail before because the `==` method is wrong.

This is because what `ActiveModel::GlobalID#model_id` returns is a string.

I was just about to update that PR, but saw it was merged. :sweat_smile:
