### PR TITLE
Update wanted list

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ We currently have adapters for:
 
 We would like to have adapters for:
 
-* beanstalkd
-* rabbitmq
+* QueueClassic
+* Sneakers
 
 
 ## Under development as a gem, targeted for Rails inclusion


### PR DESCRIPTION
beanstalkd and rabbitmq are MQ servers, they aren't something that would integrate directly with Rails and ActiveJob.  That's like saying we want an adapter for Redis, when really you want adapters for Resque, Sidekiq, etc.

Sneakers is the latest Ruby job system using rabbitmq.  I don't know of a modern beanstalkd system for Ruby, Stalker is pretty dead these days.  I added QueueClassic because it's reasonably popular on Heroku for the "postgresql only" crowd.
