### PR TITLE
Reimplement Sidekiq adapter

### DIFF
--- a/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -5,8 +5,11 @@ module ActiveJob
     class SidekiqAdapter
       class << self
         def queue(job, *args)
-          item = { 'class' => JobWrapper, 'queue' => job.queue_name, 'args' => [job, *args] }
-          Sidekiq::Client.push(job.get_sidekiq_options.merge(item))
+          item = { 'class' => JobWrapper,
+                   'queue' => job.queue_name,
+                   'args' => [job, *args],
+                   'retry' => true }
+          Sidekiq::Client.push(item)
         end
       end
 
@@ -15,14 +18,9 @@ module ActiveJob
 
         def perform(job_name, *args)
           instance = job_name.constantize.new
-          instance.jid = self.jid
           instance.perform *Parameters.deserialize(args)
         end
       end
     end
   end
-end
-
-class ActiveJob::Base
-  include Sidekiq::Worker
 end


### PR DESCRIPTION
This better integrates various Sidekiq features into AJ jobs.

Things like the JID will be set as expected and the user can use `sidekiq_options` in AJ::Base subclasses as usual to configure various Sidekiq features:

``` ruby
class MyJob < ActiveJob::Base
  sidekiq_options retry: 5, dead: false

  def perform(...)
  end
end
```
