### PR TITLE
Require global_identification in serialisations

### DIFF
--- a/lib/active_job/arguments.rb
+++ b/lib/active_job/arguments.rb
@@ -1,4 +1,5 @@
 require 'active_model/global_locator'
+require 'active_model/global_identification'
 
 module ActiveJob
   class Arguments


### PR DESCRIPTION
Including activejob in other gems will raise an uninitialized constant `ActiveModel::GlobalIdentification`
