### PR TITLE
Call #to_s when serializing GlobalID. Fix #95

### DIFF
--- a/lib/active_job/arguments.rb
+++ b/lib/active_job/arguments.rb
@@ -17,7 +17,7 @@ module ActiveJob
       def self.serialize_argument(argument)
         case argument
         when ActiveModel::GlobalIdentification
-          argument.global_id
+          argument.global_id.to_s
         when *TYPE_WHITELIST
           argument
         when Array

--- a/test/cases/parameters_test.rb
+++ b/test/cases/parameters_test.rb
@@ -26,8 +26,8 @@ class ParameterSerializationTest < ActiveSupport::TestCase
   end
 
   test 'should dive deep into arrays or hashes' do
-    assert_equal [ { "a" => Person.find(5).gid }.with_indifferent_access ], ActiveJob::Arguments.serialize([ { a: Person.find(5) } ])
-    assert_equal [ [ Person.find(5).gid ] ], ActiveJob::Arguments.serialize([ [ Person.find(5) ] ])
+    assert_equal [ { "a" => Person.find(5).gid.to_s }.with_indifferent_access ], ActiveJob::Arguments.serialize([ { a: Person.find(5) } ])
+    assert_equal [ [ Person.find(5).gid.to_s ] ], ActiveJob::Arguments.serialize([ [ Person.find(5) ] ])
   end
 
   test 'should dive deep into arrays or hashes and raise exception on complex objects' do
@@ -45,11 +45,11 @@ class ParameterSerializationTest < ActiveSupport::TestCase
   end
 
   test 'should serialize records with global id' do
-    assert_equal [ Person.find(5).gid ], ActiveJob::Arguments.serialize([ Person.find(5) ])
+    assert_equal [ Person.find(5).gid.to_s ], ActiveJob::Arguments.serialize([ Person.find(5) ])
   end
 
   test 'should serialize values and records together' do
-    assert_equal [ 3, Person.find(5).gid ], ActiveJob::Arguments.serialize([ 3, Person.find(5) ])
+    assert_equal [ 3, Person.find(5).gid.to_s ], ActiveJob::Arguments.serialize([ 3, Person.find(5) ])
   end
 end
 


### PR DESCRIPTION
This is another approach to fix #95 by calling `to_s` when serializing ActiveModel::GlobalId object, so that there's no ambiguity about how to serialize GlobalId object regardless of the queue backend.

Thanks @zzak for the suggestion :heart:
