### PR TITLE
Fix database serialization of job class names with Que

### DIFF
--- a/lib/active_job/queue_adapters/que_adapter.rb
+++ b/lib/active_job/queue_adapters/que_adapter.rb
@@ -5,7 +5,7 @@ module ActiveJob
     class QueAdapter
       class << self
         def enqueue(job, *args)
-          JobWrapper.enqueue job, *args, queue: job.queue_name
+          JobWrapper.enqueue job.to_s, *args, queue: job.queue_name
         end
 
         def enqueue_at(job, timestamp, *args)
@@ -15,7 +15,7 @@ module ActiveJob
 
       class JobWrapper < Que::Job
         def run(job, *args)
-          job.new.execute *args
+          job.constantize.new.execute *args
         end
       end
     end


### PR DESCRIPTION
This change fixes a breakage with using the Que adapter and serializing jobs to the database (as opposed to Que's `:sync` mode, which is used in the Active Job tests, and doesn't seralize jobs to the database).

When passing the job class constant as the first `#enqueue` argument, Que’s stored procedures serialize it to JSON in the database as `{}`. This means that when the job (the ActiveJob “wrapper”) is deserialized from the database, it can’t find the original job class to run again.

Changing the Que adapter to serialize the job class as a string fixes this behaviour. This change makes the adapter consistent with other adapters too (which constantize a class string in their `JobWrapper#perform` methods).

All the tests still pass with this change. I wasn't sure if it needed any new ones added. What it really needs to exercise to change are some integration-style tests, but it looks like this sort of thing doesn't exist in Active Job yet. Would it be OK to merge this as-is, then?

Thanks!
