### PR TITLE
Fixed qu, queue_classic, sneakers adapters

### DIFF
--- a/lib/active_job/queue_adapters/qu_adapter.rb
+++ b/lib/active_job/queue_adapters/qu_adapter.rb
@@ -5,7 +5,9 @@ module ActiveJob
     class QuAdapter
       class << self
         def enqueue(job, *args)
-          Qu::Payload.new(klass: JobWrapper, args: [job, *args], queue: job.queue_name).push
+          Qu::Payload.new(klass: JobWrapper, args: [job.name, *args]).tap do |payload|
+            payload.instance_variable_set(:@queue, job.queue_name)
+          end.push
         end
 
         def enqueue_at(job, timestamp, *args)
@@ -14,8 +16,8 @@ module ActiveJob
       end
 
       class JobWrapper < Qu::Job
-        def initialize(job, *args)
-          @job  = job
+        def initialize(job_name, *args)
+          @job  = job_name.constantize
           @args = args
         end
 

--- a/lib/active_job/queue_adapters/queue_classic_adapter.rb
+++ b/lib/active_job/queue_adapters/queue_classic_adapter.rb
@@ -5,7 +5,7 @@ module ActiveJob
     class QueueClassicAdapter
       class << self
         def enqueue(job, *args)
-          QC::Queue.new(job.queue_name).enqueue("#{JobWrapper.name}.perform", job, *args)
+          QC::Queue.new(job.queue_name).enqueue("#{JobWrapper.name}.perform", job.name, *args)
         end
 
         def enqueue_at(job, timestamp, *args)
@@ -14,8 +14,8 @@ module ActiveJob
       end
 
       class JobWrapper
-        def self.perform(job, *args)
-          job.new.execute *args
+        def self.perform(job_name, *args)
+          job_name.constantize.new.execute *args
         end
       end
     end


### PR DESCRIPTION
This fixes the bugs I found while working on the integration testing at #102

qu:
- job class is converted to string when serialized by qu's backend
- because of the way the queue name was handled internally by qu the jobs were always run from the default queue

queue_classic:
- job class is converted to string when serialized by queue_classic's backend

sneakers:
- because sneakers' `.enqueue` publishes directly to MQ it should only receive one argument which is a string
