### PR TITLE
Remove stray variable to fix the warning shown when resque-scheduler can't be loaded

### DIFF
--- a/lib/active_job/queue_adapters/resque_adapter.rb
+++ b/lib/active_job/queue_adapters/resque_adapter.rb
@@ -9,7 +9,7 @@ rescue LoadError
     require 'resque_scheduler'
   rescue LoadError
     $stderr.puts 'The ActiveJob resque adapter requires resque-scheduler. Please add it to your Gemfile and run bundle install'
-    raise e
+    raise
   end
 end
 


### PR DESCRIPTION
Stray `e` variable leftover from 38ee4fd.
